### PR TITLE
下载工具页面兼容性修复

### DIFF
--- a/Gr33kLibrary/views.py
+++ b/Gr33kLibrary/views.py
@@ -916,7 +916,13 @@ def download_tool(request,tool_id):
                             break
 
             tool = Tool.objects.get(id=int(tool_id))
-            response = StreamingHttpResponse(file_iterator(BASE_DIR + tool.path.split('/zslibrary')[-1]))
+            #bug - 执行路径重复写入ubuntu21 #做一次文件判断进行兼容
+            tool_filename = BASE_DIR + tool.path.split('/zslibrary')[-1]
+            if not os.path.isfile(tool_filename):
+                tool_filename = tool.path.split('/zslibrary')[-1]
+            response = StreamingHttpResponse(file_iterator(tool_filename))
+            
+            #response = StreamingHttpResponse(file_iterator(BASE_DIR + tool.path.split('/zslibrary')[-1]))
             response['Content-Type'] = 'application/octet-stream'
             response['Content-Disposition'] = 'attachment;filename="' + tool.path.split('/')[-1].encode("utf-8").decode("ISO-8859-1") + '"'
             return response


### PR DESCRIPTION
Ubuntu21.04 路径重复写入导致工具无法下载
![image](https://user-images.githubusercontent.com/41250467/134612393-0331a118-fd69-40a5-afbd-c7e6dae5b541.png)
![image](https://user-images.githubusercontent.com/41250467/134612409-af29e011-1245-4c0c-9d64-8fc28b578a9c.png)

